### PR TITLE
feat(calc101): operações aritméticas com testes

### DIFF
--- a/cs-ai-journey/01-python-fundamentals/calc101/ops.py
+++ b/cs-ai-journey/01-python-fundamentals/calc101/ops.py
@@ -1,0 +1,13 @@
+def soma(a, b):
+    return a + b
+
+def sub(a, b):
+    return a - b
+
+def mul(a, b):
+    return a * b
+
+def div(a, b):
+    if b == 0:
+        raise ZeroDivisionError("b não pode ser zero")
+    return a / b

--- a/cs-ai-journey/01-python-fundamentals/tests/test_ops.py
+++ b/cs-ai-journey/01-python-fundamentals/tests/test_ops.py
@@ -1,0 +1,19 @@
+from calc101.ops import soma, sub, mul, div
+import pytest
+
+def test_soma():
+    assert soma(2, 3) == 5
+
+def test_sub():
+    assert sub(5, 3) == 2
+
+def test_mul():
+    assert mul(4, 2) == 8
+
+def test_div():
+    assert div(6, 3) == 2
+
+def test_div_zero():
+    import pytest
+    with pytest.raises(ZeroDivisionError):
+        div(1, 0)


### PR DESCRIPTION
# O que foi feito
- Implementa mini-lib `calc101` com soma, sub, mul, div.
- Testes com pytest, incluindo divisão por zero.

# Como testar
- Ativar venv em `01-python-fundamentals`
- `pip install pytest`
- `PYTHONPATH=. pytest -q`

# Checklist
- [x] Testes passando
- [x] Commits atômicos e claros
- [x] Estrutura de pastas organizada
